### PR TITLE
Hotfix a crush that happens because .env file can improperly change : to \x3a

### DIFF
--- a/ratwork_mechanism_bot/config/config.py
+++ b/ratwork_mechanism_bot/config/config.py
@@ -7,7 +7,7 @@ import dotenv
 
 from .queries import SETUP_QUERY
 
-dotenv.load_dotenv()
+dotenv.load_dotenv(override=True)
 
 DISCORD_TOKEN = os.getenv("DISCORD_TOKEN", "")
 TEST_SERVER_ID = os.getenv("TEST_SERVER_ID", "")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated environment variable loading so that values from the `.env` file now overwrite any existing environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->